### PR TITLE
Update adapter templates

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -137,7 +137,7 @@
             "label": "CMSIS Erase",
             "type": "shell",
             "command": [
-                "pyocd erase --probe cmsisdap: --chip --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd erase --probe cmsisdap: --chip --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },
@@ -145,7 +145,7 @@
             "label": "CMSIS Load",
             "type": "shell",
             "command": [
-                "pyocd load --probe cmsisdap: --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd load --probe cmsisdap: --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },
@@ -153,7 +153,7 @@
             "label": "CMSIS Run",
             "type": "shell",
             "command": [
-                "pyocd gdbserver --probe cmsisdap: --connect attach --persist --reset-run --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd gdbserver --probe cmsisdap: --connect attach --persist --reset-run --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },

--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -23,8 +23,7 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "--probe", "cmsisdap:",
-                    "--connect", "attach",
-                    "--persist"
+                    "--connect", "attach"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -23,8 +23,7 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "--probe", "stlink:",
-                    "--connect", "attach",
-                    "--persist"
+                    "--connect", "attach"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -137,7 +137,7 @@
             "label": "CMSIS Erase",
             "type": "shell",
             "command": [
-                "pyocd erase --probe stlink: --chip --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd erase --probe stlink: --chip --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },
@@ -145,7 +145,7 @@
             "label": "CMSIS Load",
             "type": "shell",
             "command": [
-                "pyocd load --probe stlink: --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd load --probe stlink: --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },
@@ -153,7 +153,7 @@
             "label": "CMSIS Run",
             "type": "shell",
             "command": [
-                "pyocd gdbserver --probe stlink: --connect attach --persist --reset-run --cbuild-run ${command:cmsis-csolution.getCbuildRunFile}"
+                "pyocd gdbserver --probe stlink: --connect attach --persist --reset-run --cbuild-run \"${command:cmsis-csolution.getCbuildRunFile}\""
             ],
             "problemMatcher": []
         },


### PR DESCRIPTION
- Remove "--persist" options from pyOCD single-core launch scripts
- Add quotes to support spaces in the cbuild-run file name