### PR TITLE
adding registry and templates for Arm-Debugger

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -8,7 +8,8 @@ debug-adapters:
       protocol: swd
       clock: 10000000
 
-  - name: "ULINKplus"
+  - name: "ULINKplus@pyOCD"
+    alias-name: ["ULINKplus"]                 # alternative names that map to this debug adapter
     template: CMSIS-DAP-pyOCD.adapter.json    # template file (initally same as CMSIS-DAP@pyOCD)
     gdbserver:                                # add gdbserver: node under debugger: in cbuild-run.yml
     defaults:                                 # default values to use when nowhere specified
@@ -67,6 +68,14 @@ debug-adapters:
     defaults:                                 # default values to use when nowhere specified
       port: 3333                              # default value of first gdbserver port
       protocol: swd
+
+  - name: "CMSIS-DAP@Arm-Debugger"
+    alias-name: ["CMSIS-DAP@armdbg"]
+    template: CMSIS-DAP-Arm-Debugger.adapter.json
+
+  - name: "ST-Link@Arm-Debugger"
+    alias-name: ["ST-Link@armdbg"]
+    template: STLink-Arm-Debugger.adapter.json
 
   - name: "AVH-FVP"
     template: FVP.adapter.json                # template file

--- a/templates/CMSIS-DAP-Arm-Debugger.adapter.json
+++ b/templates/CMSIS-DAP-Arm-Debugger.adapter.json
@@ -1,0 +1,30 @@
+{
+    "launch": {
+        "singlecore-launch": {
+            "name": "CMSIS-DAP@Arm-Debugger (launch)",
+            "type": "arm-debugger",
+            "request": "launch",
+            "serialNumber": "*",
+            "probe": "CMSIS-DAP",
+            "programs": "${command:cmsis-csolution.getBinaryFiles}",
+            "cmsisPack": "${command:cmsis-csolution.getDfpName}",
+            "deviceName": "${command:cmsis-csolution.getDeviceName}",
+            "processorName": "${command:cmsis-csolution.getProcessorName}",
+            "workspaceFolder": "${workspaceFolder}/<%= solution_folder %>"
+        }
+    },
+    "tasks": [
+        {
+            "label": "CMSIS Load+Run",
+            "type": "arm-debugger.flash",
+            "serialNumber": "${command:device-manager.getSerialNumber}",
+            "probe": "CMSIS-DAP",
+            "programs": "${command:cmsis-csolution.getBinaryFiles}",
+            "cmsisPack": "${command:cmsis-csolution.getDfpName}",
+            "deviceName": "${command:cmsis-csolution.getDeviceName}",
+            "processorName": "${command:cmsis-csolution.getProcessorName}",
+            "workspaceFolder": "${workspaceFolder}/<%= solution_folder %>",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/templates/STLink-Arm-Debugger.adapter.json
+++ b/templates/STLink-Arm-Debugger.adapter.json
@@ -1,0 +1,30 @@
+{
+    "launch": {
+        "singlecore-launch": {
+            "name": "STLink@Arm-Debugger (launch)",
+            "type": "arm-debugger",
+            "request": "launch",
+            "serialNumber": "*",
+            "probe": "ST-Link",            
+            "programs": "${command:cmsis-csolution.getBinaryFiles}",
+            "cmsisPack": "${command:cmsis-csolution.getDfpName}",
+            "deviceName": "${command:cmsis-csolution.getDeviceName}",
+            "processorName": "${command:cmsis-csolution.getProcessorName}",
+            "workspaceFolder": "${workspaceFolder}/<%= solution_folder %>"
+        }
+    },
+    "tasks": [
+        {
+            "label": "CMSIS Load+Run",
+            "type": "arm-debugger.flash",
+            "serialNumber": "${command:device-manager.getSerialNumber}",
+            "probe": "ST-Link",
+            "programs": "${command:cmsis-csolution.getBinaryFiles}",
+            "cmsisPack": "${command:cmsis-csolution.getDfpName}",
+            "deviceName": "${command:cmsis-csolution.getDeviceName}",
+            "processorName": "${command:cmsis-csolution.getProcessorName}",
+            "workspaceFolder": "${workspaceFolder}/<%= solution_folder %>",
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
a) aligned naming for adapter ULINKplus for pyOCD
b) added ST-Link and CMSIS-DAP for Arm-Debugger
known caveat is that the flash programming does not work correctly without the Arm Device Manager extension to retrieve the debug adapters SerialNumber. A defect has been raised against the Arm Debugger Extension.

implementing: https://github.com/ARM-software/vscode-cmsis-csolution/issues/255