### PR TITLE
Add alias-name to JLink Server adapter

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -63,6 +63,7 @@ debug-adapters:
       clock: 10000000
 
   - name: "JLink Server"
+    alias-name: ["J-Link"]                    # alternative names that map to this debug adapter
     template: JLink.adapter.json              # template file
     gdbserver:                                # add gdbserver: node under debugger: in cbuild-run.yml
     defaults:                                 # default values to use when nowhere specified


### PR DESCRIPTION
fix part two of https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/issues/354