### PR TITLE
Complete mandatory serverParameter args

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -22,8 +22,11 @@
             "target": {
                 "server": "pyocd",
                 "serverParameters": [
+                    "gdbserver",
+                    "--port", "<%= ports.get(pname) %>",
                     "--probe", "cmsisdap:",
-                    "--connect", "attach"
+                    "--connect", "attach",
+                    "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },
@@ -77,9 +80,12 @@
             "target": {
                 "server": "pyocd",
                 "serverParameters": [
+                    "gdbserver",
+                    "--port", "<%= ports.get(pname) %>",
                     "--probe", "cmsisdap:",
                     "--connect", "attach",
-                    "--persist"
+                    "--persist",
+                    "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -29,7 +29,8 @@
                     "-noir",
                     "-vd",
                     "-nogui",
-                    "-localhostonly"
+                    "-localhostonly",
+                    "-port", "<%= ports.get(pname) %>"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },
@@ -89,7 +90,8 @@
                     "-noir",
                     "-vd",
                     "-nogui",
-                    "-localhostonly"
+                    "-localhostonly",
+                    "-port", "<%= ports.get(pname) %>"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },
@@ -143,7 +145,8 @@
                     "-noir",
                     "-vd",
                     "-nogui",
-                    "-localhostonly"
+                    "-localhostonly",
+                    "-port", "<%= ports.get(pname) %>"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -22,8 +22,11 @@
             "target": {
                 "server": "pyocd",
                 "serverParameters": [
+                    "gdbserver",
+                    "--port", "<%= ports.get(pname) %>",
                     "--probe", "stlink:",
-                    "--connect", "attach"
+                    "--connect", "attach",
+                    "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },
@@ -77,9 +80,12 @@
             "target": {
                 "server": "pyocd",
                 "serverParameters": [
+                    "gdbserver",
+                    "--port", "<%= ports.get(pname) %>",
                     "--probe", "stlink:",
                     "--connect", "attach",
-                    "--persist"
+                    "--persist",
+                    "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
                 ],
                 "port": "<%= ports.get(pname) %>"
             },


### PR DESCRIPTION
Part of https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/338

* Completes pyOCD and J-LINK templates with mandatory `serverParameter`s which CMSIS Debugger extension currently adds on the fly. Their original intention was to reduce the amount of `gdbtarget` settings a user would need to worry about. This became obsolete with launch config management in Arm CMSIS Solution extension.
* Magic in CMSIS Debugger remains after first CMSIS Solution extension release that can pick these changes up.
* `cmsis`>`cbuildRunFile` needs to stay to have a well-defined location for debug view extensions to pick up additional info (like SVD file location).

Note: Changes not yet tested. But adding reviewers already in case of questions.