### PR TITLE
Added RPi Debug Probe

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -53,6 +53,15 @@ debug-adapters:
       protocol: swd
       clock: 10000000
 
+  - name: "RPiDebugProbe@pyOCD"
+    alias-name: ["RaspberryPiDebugProbe"]     # alternative names that map to this debug adapter
+    template: CMSIS-DAP-pyOCD.adapter.json    # template file
+    gdbserver:                                # add gdbserver: node under debugger: in cbuild-run.yml
+    defaults:                                 # default values to use when nowhere specified
+      port: 3333                              # default value of first gdbserver port
+      protocol: swd
+      clock: 10000000
+
   - name: "ST-Link@pyOCD"
     alias-name: ["ST-LINK"]                   # alternative names that map to this debug adapter
     template: STLink-pyOCD.adapter.json       # template file


### PR DESCRIPTION
Raspberry Pi offers a versatile CMSIS-DAP v2-based debug probe. Adding for completeness.