### PR TITLE
fix missing quotes

### DIFF
--- a/templates/STLink-Arm-Debugger.adapter.json
+++ b/templates/STLink-Arm-Debugger.adapter.json
@@ -5,7 +5,7 @@
             "type": "arm-debugger",
             "request": "launch",
             "connectionAddress": "${command:device-manager.getSerialNumber}",
-            "connectionType: "ST-Link",
+            "connectionType": "ST-Link",
             "programs": "${command:cmsis-csolution.getBinaryFiles}",
             "cmsisPack": "${command:cmsis-csolution.getDfpName}",
             "deviceName": "${command:cmsis-csolution.getDeviceName}",


### PR DESCRIPTION
The last update was missing a `"` and as a result was not creating a valid launch.json