### PR TITLE
Add gdbtarget customResetCommands for multicore-other

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -130,6 +130,9 @@
                 "symbol-file <%= files[i] %><%= i < files.length - 1 ? \"\\n\" : '' %>",
                 "<% } %>"
             ],
+            "customResetCommands": [
+                "monitor reset halt"
+            ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
             },

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -135,6 +135,9 @@
                 "symbol-file <%= files[i] %><%= i < files.length - 1 ? \"\\n\" : '' %>",
                 "<% } %>"
             ],
+            "customResetCommands": [
+                "monitor reset"
+            ],
             "target": {
                 "server": "JLinkGDBServerCL<%= platform === 'win32' ? '.exe' : 'Exe' %>",
                 "serverParameters": [

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -130,6 +130,9 @@
                 "symbol-file <%= files[i] %><%= i < files.length - 1 ? \"\\n\" : '' %>",
                 "<% } %>"
             ],
+            "customResetCommands": [
+                "monitor reset halt"
+            ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
             },


### PR DESCRIPTION
Adds `customResetCommands` for `multicore-other` configs that make use of CDT GDB adapter (debugger type `gdbtarget`).
Otherwise, only the start-core can be reset from the debug toolbar.
See https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/327

Note: This may require fine-tuning of reset types going forward. CPU connections may not be recoverable after reset, often depending on reset type and target system design.