### PR TITLE
Remove port serverParameter for pyOCD adapters

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -23,7 +23,6 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "gdbserver",
-                    "--port", "<%= ports.get(pname) %>\n",
                     "--probe", "cmsisdap:",
                     "--connect", "attach",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
@@ -81,7 +80,6 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "gdbserver",
-                    "--port", "<%= ports.get(pname) %>\n",
                     "--probe", "cmsisdap:",
                     "--connect", "attach",
                     "--persist",
@@ -246,7 +244,6 @@
             },
             "args": [
                 "gdbserver",
-                "--port", "<%= ports.get(start_pname) %>\n",
                 "--probe", "cmsisdap:",
                 "--connect", "attach",
                 "--persist",

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -23,7 +23,6 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "gdbserver",
-                    "--port", "<%= ports.get(pname) %>\n",
                     "--probe", "stlink:",
                     "--connect", "attach",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}"
@@ -81,7 +80,6 @@
                 "server": "pyocd",
                 "serverParameters": [
                     "gdbserver",
-                    "--port", "<%= ports.get(pname) %>\n",
                     "--probe", "stlink:",
                     "--connect", "attach",
                     "--persist",
@@ -246,7 +244,6 @@
             },
             "args": [
                 "gdbserver",
-                "--port", "<%= ports.get(start_pname) %>\n",
                 "--probe", "stlink:",
                 "--connect", "attach",
                 "--persist",


### PR DESCRIPTION
In pyOCD, when the `--cbuild-run` parameter is specified, port information is read from the `.cbuild-run.yml` file.