### PR TITLE
Run to main after reset (pyOCD)

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -17,7 +17,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "pyocd",
@@ -49,7 +51,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -75,7 +79,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "pyocd",
@@ -108,7 +114,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -131,7 +139,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -17,7 +17,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset"
+                "monitor reset",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "JLinkGDBServerCL<%= platform === 'win32' ? '.exe' : 'Exe' %>",
@@ -52,7 +54,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset"
+                "monitor reset",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -78,7 +82,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset"
+                "monitor reset",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "JLinkGDBServerCL<%= platform === 'win32' ? '.exe' : 'Exe' %>",
@@ -113,7 +119,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset"
+                "monitor reset",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -136,7 +144,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset"
+                "monitor reset",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "JLinkGDBServerCL<%= platform === 'win32' ? '.exe' : 'Exe' %>",

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -17,7 +17,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "pyocd",
@@ -49,7 +51,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -75,7 +79,9 @@
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "server": "pyocd",
@@ -108,7 +114,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"
@@ -131,7 +139,9 @@
                 "<% } %>"
             ],
             "customResetCommands": [
-                "monitor reset halt"
+                "monitor reset halt",
+                "tbreak main",
+                "continue"
             ],
             "target": {
                 "port": "<%= ports.get(pname) %>"


### PR DESCRIPTION
Temporary change to ensure we get a proper GUI refresh after reset.

Adds
```
"tbreak main",
"continue"
```
to `customResetCommands` for pyOCD based debuggers.

Changes applied to pyOCD and J-LINK GDB Server based debuggers.