### PR TITLE
Suppress gdbserver CoreSight discovery output in pyOCD adapters

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -27,7 +27,7 @@
                     "--probe", "cmsisdap:",
                     "--connect", "attach",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                    "-quiet",
+                    "--quiet",
                     "--log", "*.cbuild_run,*server=info"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -88,7 +88,7 @@
                     "--connect", "attach",
                     "--persist",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                    "-quiet",
+                    "--quiet",
                     "--log", "*.cbuild_run,*server=info"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -256,7 +256,7 @@
                 "--persist",
                 "--reset-run",
                 "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                "-quiet",
+                "--quiet",
                 "--log", "*.cbuild_run,*server=info"
             ],
             "problemMatcher": []

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -27,7 +27,7 @@
                     "--probe", "stlink:",
                     "--connect", "attach",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                    "-quiet",
+                    "--quiet",
                     "--log", "*.cbuild_run,*server=info"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -88,7 +88,7 @@
                     "--connect", "attach",
                     "--persist",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                    "-quiet",
+                    "--quiet",
                     "--log", "*.cbuild_run,*server=info"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -256,7 +256,7 @@
                 "--persist",
                 "--reset-run",
                 "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
-                "-quiet",
+                "--quiet",
                 "--log", "*.cbuild_run,*server=info"
             ],
             "problemMatcher": []


### PR DESCRIPTION
Added pyOCD command line arguments suppress the CoreSight discovery output when launching `gdbserver`.
```json
"--quiet",
"--log", "*.cbuild_run,*server=info"
```

https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/267