### PR TITLE
Add cbuild-run file for other extension to read

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -60,6 +60,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -124,6 +125,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -149,6 +151,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         }

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -37,6 +37,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -62,6 +63,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -102,6 +104,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -127,6 +130,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -164,6 +168,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         }

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -60,6 +60,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -124,6 +125,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         },
@@ -149,6 +151,7 @@
                 "port": "<%= ports.get(pname) %>"
             },
             "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
                 "updateConfiguration": "auto"
             }
         }


### PR DESCRIPTION
Addresses https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/428 :

Add cbuild-run file to pyOCD and J-LINK launch configs for CMSIS Debugger extension to extract SVD file path for Peripheral Inspector. Even if gdbserver itself cannot consume the file.