### PR TITLE
Add file to the enumerated values for type

### DIFF
--- a/schemas/debug-adapters.schema.json
+++ b/schemas/debug-adapters.schema.json
@@ -103,7 +103,8 @@
           "enum": [
             "number",
             "enum",
-            "string"
+            "string",
+            "file"
           ],
           "description": "Type of the user interface element."
         },


### PR DESCRIPTION
In the proposal of the user-interface there is a type `file` defined, that should open a file browse dialog for the user to select a file. At this point we do not have a file extension filter definition, therefore I would list all files without a filter for now.