### PR TITLE
add file to type enum for sectionOptions

### DIFF
--- a/schemas/debug-adapters.schema.json
+++ b/schemas/debug-adapters.schema.json
@@ -147,7 +147,8 @@
             "enum": [
               "number",
               "enum",
-              "string"
+              "string",
+              "file"
             ],
             "description": "Type of the option."
           },


### PR DESCRIPTION
Add type: `file` to the options settings.