### PR TITLE
Add 'auxiliaryGdb' property to 'gdbtarget' based templates.

### DIFF
--- a/schemas/templates.schema.json
+++ b/schemas/templates.schema.json
@@ -36,6 +36,7 @@
         "program":             { "type": "string" },
         "programs":            { "type": "array", "items": { "type": "string" } },
         "gdb":                 { "type": "string" },
+        "auxiliaryGdb":        { "type": "boolean"},
         "preLaunchTask":       { "type": "string" },
         "connectionAddress":   { "type": "string" },
         "connectionType":      { "type": "string" },

--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -7,6 +7,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
@@ -45,6 +46,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -71,6 +73,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
@@ -110,6 +113,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -136,6 +140,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -7,6 +7,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
@@ -48,6 +49,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -74,6 +76,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
@@ -115,6 +118,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -141,6 +145,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -7,6 +7,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
@@ -45,6 +46,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -71,6 +73,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
@@ -110,6 +113,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",
@@ -136,6 +140,7 @@
             "cwd": "${workspaceFolder}/<%= solution_folder %>",
             "program": "<%= symbol_files.filter(s => s.pname === pname)[0]?.file || '' %>",
             "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": true,
             "initCommands": [
                 "<% const files = symbol_files.filter(s => s.pname === pname).slice(1).map(s => s.file) %>",
                 "<% for (let i = 0; i < files.length; i++) { %>",


### PR DESCRIPTION
Requires pyOCD v0.40.0 or later.

Part of https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/578