### PR TITLE
Review debug adapter defaults for pyOCD/J-Link

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -12,14 +12,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 30000]
             scale: 1000
             default: 10000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -44,14 +44,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 10000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -76,13 +76,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 10000
           - name: Protocol
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -107,14 +108,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 10000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -139,14 +140,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 10000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -171,14 +172,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 10000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -203,17 +204,20 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 10000]
             scale: 1000
             default: 1000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
-            values: [swd]
+            values:
+              - name: SWD
+                value: swd
+                description: Use SWD protocol for debugging
             default: swd
 
   - name: "ST-Link@pyOCD"
@@ -229,14 +233,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 24000]
             scale: 1000
             default: 4000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:
@@ -261,14 +265,14 @@ debug-adapters:
         description: Interface configuration for the debug port
         options:
           - name: Clock (kHz)
-            description: Clock configuration
+            description: Maximum debug clock
             yml-node: clock
             type: number
             range: [10, 50000]
             scale: 1000
             default: 4000
           - name: Protocol
-            description: Protocol configuration
+            description: Debug protocol
             yml-node: protocol
             type: enum
             values:


### PR DESCRIPTION
Generic updates
* Updates "Clock" descriptions: `Clock configuration` -> `Maximum debug clock`
* Updates "Protocol" descriptions: `Protocol configuration` -> `Debug protocol`

Probe specific updates
* Updates "CMSIS-DAP@pyOCD" clock range from max 10MHz to max 30MHz as per previous discussions on extending the clock range in uVision setup dialogs.
* Updates "RPiDebugProbe@pyOCD" default clock from 10MHz to 1MHz. Suggested to be the default configuration for Picoprobe builds on GitHub FW repos.
  * Also expands SWD enum value for consistency.
* Updates "ST-Link@pyOCD" clock range from max 10MHz to max 24MHz as available for ST-LinkV3 variants.
  * Also updates default clock from 10MHz to 4MHz which is a more typical value for ST-LinkV2/V2-1.
* Updates "JLink Server" clock range from max 10MHz to max 50MHz to cover high-end variants.
  * Also updates default clock from 10MHz to 4MHz which seems more likely to be the max clock for on-board variants.

Note: This PR does not update the templates yet.