### PR TITLE
Add "maintenance flush" operations to customResetCommands

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -35,6 +35,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -68,6 +70,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -95,6 +99,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -129,6 +135,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -153,6 +161,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -41,6 +41,8 @@
             ],
             "customResetCommands": [
                 "monitor reset",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -77,6 +79,8 @@
             ],
             "customResetCommands": [
                 "monitor reset",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -104,6 +108,8 @@
             ],
             "customResetCommands": [
                 "monitor reset",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -140,6 +146,8 @@
             ],
             "customResetCommands": [
                 "monitor reset",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -164,6 +172,8 @@
             ],
             "customResetCommands": [
                 "monitor reset",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -35,6 +35,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -68,6 +70,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -95,6 +99,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -129,6 +135,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],
@@ -153,6 +161,8 @@
             ],
             "customResetCommands": [
                 "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
                 "tbreak main",
                 "continue"
             ],


### PR DESCRIPTION
to improve debug behavior after resets through IDE button.

Draft for now, holding back as I am waiting for confirmation that changes in next pyOCD release help with GUI refreshs.
Then we might also be able to remove tbreak + continue commands.