### PR TITLE
Add '-silent' option to JLink adapter configuration

### DIFF
--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -57,6 +57,7 @@
                     "-vd",
                     "-nogui",
                     "-localhostonly",
+                    "-silent",
                     "-port", "<%= ports.get(pname) %>\n"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -124,6 +125,7 @@
                     "-vd",
                     "-nogui",
                     "-localhostonly",
+                    "-silent",
                     "-port", "<%= ports.get(pname) %>\n"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -188,6 +190,7 @@
                     "-vd",
                     "-nogui",
                     "-localhostonly",
+                    "-silent",
                     "-port", "<%= ports.get(pname) %>\n"
                 ],
                 "port": "<%= ports.get(pname) %>"
@@ -246,6 +249,7 @@
                 "-noir",
                 "-nogui",
                 "-localhostonly",
+                "-silent",
                 "-port", "<%= ports.get(start_pname) %>\n"
             ],
             "problemMatcher": []


### PR DESCRIPTION
fix: https://github.com/ARM-software/vscode-cmsis-csolution/issues/425