### PR TITLE
Allow `boolean` type for `value` in debug adapter schema

### DIFF
--- a/schemas/debug-adapters.schema.json
+++ b/schemas/debug-adapters.schema.json
@@ -165,7 +165,7 @@
               ],
               "properties": {
                 "name": { "type": "string", "description": "Display name of the value." },
-                "value": { "type": [ "string", "number" ], "description": "Actual value to use in the YAML file." },
+                "value": { "type": [ "string", "number", "boolean" ], "description": "Actual value to use in the YAML file." },
                 "description": { "type": "string", "description": "Description of the value." }
               },
               "required": [ "name" ]


### PR DESCRIPTION
Fix schema check issue caught in `toolbox` nightly tests:
https://github.com/Open-CMSIS-Pack/cmsis-toolbox/actions/runs/20091463812/job/57640022350