### PR TITLE
J-Link Config Updates

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -504,7 +504,7 @@ debug-adapters:
       telnet:
         active:                                            # add telnet: node under debugger: in cbuild-run.yml
         port: 4444
-        mode: monitor
+        mode: off
       protocol: swd
       clock: 4000000
     user-interface:
@@ -551,6 +551,9 @@ debug-adapters:
               - name: Serial Monitor
                 value: monitor
                 description:  Serial I/O via TCP/IP port to VS Code Serial Monitor
+              - name: Disabled
+                value: off
+                description:  Serial I/O disabled
 
   - name: "CMSIS-DAP@Arm-Debugger"
     alias-name: ["CMSIS-DAP@armdbg"]

--- a/schemas/debug-adapters.schema.json
+++ b/schemas/debug-adapters.schema.json
@@ -101,7 +101,7 @@
               "description": "Port number."
             },
             "mode": {
-              "type": "string",
+              "type": [ "string" , "boolean" ],
               "description": "Redirect output mode."
             }
           }

--- a/templates/JLink.adapter.json
+++ b/templates/JLink.adapter.json
@@ -29,11 +29,12 @@
         "resetTypesInput": "<%= config.reset && Array.isArray(config.reset) ? Object.fromEntries(config.reset.map(r => ( [ r.pname ?? '', r.type ]))) : undefined %>",
         "resetTypeDefault": "<%= config.reset?.type ?? 'system' %>",
         "telnetOptionsInput": "<%= config.telnet && Array.isArray(config.telnet) ? Object.fromEntries(config.telnet.map(t => ( [ t.pname ?? '', { mode: t.mode, port: t.port }]))) : undefined %>",
-        "telnetOptionsDefault": "<%= { mode: config.telnet?.mode ?? 'server', port: config.telnet?.port ?? '4444' } %>",
+        "telnetOptionsDefault": "<%= { mode: config.telnet?.mode ?? 'off', port: config.telnet?.port ?? '4444' } %>",
         "telnetMode": {
             "server": "1",
             "monitor": "1",
-            "console": "2"
+            "console": "2",
+            "off": "1"
         },
         "connectOptions": {
             "attach": [ "-nohalt", "-noreset" ],
@@ -54,7 +55,11 @@
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor semihosting ioclient <%= data.telnetMode[data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode] %>\n",
+                "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
+                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "monitor semihosting ioclient <%= data.telnetMode[telnetMode] %>\n",
+                "monitor semihosting enable",
+                "<% } %>",
                 "<% if (config.connect?.mode !== 'attach') { %>",
                 "monitor reset <%= data.resetOption[data.resetTypesInput[pname ?? ''] ?? data.resetTypeDefault] %>\n",
                 "tbreak main",
@@ -106,7 +111,11 @@
             "auxiliaryGdb": true,
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor semihosting ioclient <%= data.telnetMode[data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode] %>\n"
+                "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
+                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "monitor semihosting ioclient <%= data.telnetMode[telnetMode] %>\n",
+                "monitor semihosting enable",
+                "<% } %>"
             ],
             "customResetCommands": [
                 "monitor reset <%= data.resetOption[data.resetTypesInput[pname ?? ''] ?? data.resetTypeDefault] %>\n",
@@ -134,7 +143,11 @@
             "preLaunchTask": "CMSIS Load",
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor semihosting ioclient <%= data.telnetMode[data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode] %>\n",
+                "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
+                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "monitor semihosting ioclient <%= data.telnetMode[telnetMode] %>\n",
+                "monitor semihosting enable",
+                "<% } %>",
                 "<% if (config.connect?.mode !== 'attach') { %>",
                 "monitor reset <%= data.resetOption[data.resetTypesInput[pname ?? ''] ?? data.resetTypeDefault] %>\n",
                 "tbreak main",
@@ -186,7 +199,11 @@
             "auxiliaryGdb": true,
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor semihosting ioclient <%= data.telnetMode[data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode] %>\n"
+                "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
+                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "monitor semihosting ioclient <%= data.telnetMode[telnetMode] %>\n",
+                "monitor semihosting enable",
+                "<% } %>"
             ],
             "customResetCommands": [
                 "monitor reset <%= data.resetOption[data.resetTypesInput[pname ?? ''] ?? data.resetTypeDefault] %>\n",
@@ -213,7 +230,11 @@
             "auxiliaryGdb": true,
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor semihosting ioclient <%= data.telnetMode[data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode] %>\n"
+                "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
+                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "monitor semihosting ioclient <%= data.telnetMode[telnetMode] %>\n",
+                "monitor semihosting enable",
+                "<% } %>"
             ],
             "customResetCommands": [
                 "monitor reset <%= data.resetOption[data.resetTypesInput[pname ?? ''] ?? data.resetTypeDefault] %>\n",


### PR DESCRIPTION
Added template handling
* Telnet port
* Telnet mode
* Connect mode
* Reset

Added User Interface
* Telnet mode

Note: not addressed is the switch of telnet sources (semihosting vs RTT). To be addressed separately.
Tested with CMSIS Solution extension 1.2.1-pr658-g43e7bf2.0
Note that required patch of debug-adapters.schema.json in CMSIS Toolbox