### PR TITLE
Enable semihosting for pyOCD for 'launch' configs

### DIFF
--- a/templates/CMSIS-DAP-pyOCD.adapter.json
+++ b/templates/CMSIS-DAP-pyOCD.adapter.json
@@ -16,9 +16,7 @@
             }
         },
         "program": "<%= symbol_files[0]?.file ?? '' %>",
-        "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>",
-        "telnetOptionsInput": "<%= config.telnet && Array.isArray(config.telnet) ? Object.fromEntries(config.telnet.map(t => ( [ t.pname ?? '', { mode: t.mode }]))) : undefined %>",
-        "telnetOptionsDefault": "<%= { mode: config.telnet?.mode ?? 'off' } %>"
+        "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>"
     },
     "launch": {
         "singlecore-launch": {
@@ -51,8 +49,7 @@
                     "--uid", "<%= config['probe-id'] %>\n",
                     "<% } %>",
                     "--connect", "attach",
-                    "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                    "<% if (telnetMode && telnetMode !== 'off') { %>",
+                    "<% if (config.telnet) { %>",
                     "--semihosting",
                     "<% } %>",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
@@ -123,8 +120,7 @@
                     "<% } %>",
                     "--connect", "attach",
                     "--persist",
-                    "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                    "<% if (telnetMode && telnetMode !== 'off') { %>",
+                    "<% if (config.telnet) { %>",
                     "--semihosting",
                     "<% } %>",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
@@ -246,8 +242,7 @@
                 "--connect", "attach",
                 "--persist",
                 "--reset-run",
-                "<% const telnetMode = data.telnetOptionsInput[start_pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "<% if (config.telnet) { %>",
                 "--semihosting",
                 "<% } %>",
                 "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",

--- a/templates/STLink-pyOCD.adapter.json
+++ b/templates/STLink-pyOCD.adapter.json
@@ -16,9 +16,7 @@
             }
         },
         "program": "<%= symbol_files[0]?.file ?? '' %>",
-        "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>",
-        "telnetOptionsInput": "<%= config.telnet && Array.isArray(config.telnet) ? Object.fromEntries(config.telnet.map(t => ( [ t.pname ?? '', { mode: t.mode }]))) : undefined %>",
-        "telnetOptionsDefault": "<%= { mode: config.telnet?.mode ?? 'off' } %>"
+        "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>"
     },
     "launch": {
         "singlecore-launch": {
@@ -51,8 +49,7 @@
                     "--uid", "<%= config['probe-id'] %>\n",
                     "<% } %>",
                     "--connect", "attach",
-                    "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                    "<% if (telnetMode && telnetMode !== 'off') { %>",
+                    "<% if (config.telnet) { %>",
                     "--semihosting",
                     "<% } %>",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
@@ -123,8 +120,7 @@
                     "<% } %>",
                     "--connect", "attach",
                     "--persist",
-                    "<% const telnetMode = data.telnetOptionsInput[pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                    "<% if (telnetMode && telnetMode !== 'off') { %>",
+                    "<% if (config.telnet) { %>",
                     "--semihosting",
                     "<% } %>",
                     "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",
@@ -246,8 +242,7 @@
                 "--connect", "attach",
                 "--persist",
                 "--reset-run",
-                "<% const telnetMode = data.telnetOptionsInput[start_pname ?? '']?.mode ?? data.telnetOptionsDefault.mode %>",
-                "<% if (telnetMode && telnetMode !== 'off') { %>",
+                "<% if (config.telnet) { %>",
                 "--semihosting",
                 "<% } %>",
                 "--cbuild-run", "${command:cmsis-csolution.getCbuildRunFile}",


### PR DESCRIPTION
* Adds `-S` to pyOCD `launch` configurations (single and multi-core) if `telnet`>`mode` setting exists and is different from `off`.
* Note the implementation is copied from J-Link but without `port` which should be set via cbuild-run.yml. Could be further cleaned up but leaving as is due to limited time.

NOTE: Only did a quick test with a multicore launch config with CMSIS-DAP@pyOCD. Other variants need more testing before release.