### PR TITLE
Add Arm-FVP launch configuration in templates

### DIFF
--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -661,7 +661,7 @@ debug-adapters:
       model: "FVP_MPS2_Cortex-M3"
       gdbserver:
         active:
-        port: 10000
+        port: 3333
     user-interface:
       - section: Model
         description: Arm FVP simulation model setup

--- a/registry/debug-adapters.yml
+++ b/registry/debug-adapters.yml
@@ -659,6 +659,9 @@ debug-adapters:
     template: FVP.adapter.json                             # template files
     defaults:
       model: "FVP_MPS2_Cortex-M3"
+      gdbserver:
+        active:
+        port: 10000
     user-interface:
       - section: Model
         description: Arm FVP simulation model setup

--- a/templates/FVP.adapter.json
+++ b/templates/FVP.adapter.json
@@ -17,7 +17,7 @@
         },
         "program": "<%= symbol_files[0]?.file ?? '' %>",
         "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>",
-        "gdbServerPlugin": "${env:AVH_FVP_PLUGINS}<%= platform === 'win32' ? 'GDBServer.dll' : 'GDBServer.so' %>",
+        "gdbServerPlugin": "${env:AVH_FVP_PLUGINS}/<%= platform === 'win32' ? 'GDBServer.dll' : 'GDBServer.so' %>",
         "modelParameters": [
             "<% if (config['config-file']) { %>",
             "-f", "<%= config['config-file'] %>\n",
@@ -28,7 +28,7 @@
             "<% else if (typeof config.args === 'string' && config.args.trim().length > 0) { %>",
             "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
             "<% } %>",
-            "<% const files = image_files.length ? image_files.map(s => s.file) : [symbol_files[0]?.file ?? ''].filter(Boolean) %>",
+            "<% const files = image_files.map(s => s.file) %>",
             "<% for (const [idx, file] of files.entries()) { %>",
             "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
             "<% } %>"

--- a/templates/FVP.adapter.json
+++ b/templates/FVP.adapter.json
@@ -17,7 +17,22 @@
         },
         "program": "<%= symbol_files[0]?.file ?? '' %>",
         "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>",
-        "gdbServerPlugin": "${env:AVH_FVP_PLUGINS}<%= platform === 'win32' ? 'GDBServer.dll' : 'GDBServer.so' %>"
+        "gdbServerPlugin": "${env:AVH_FVP_PLUGINS}<%= platform === 'win32' ? 'GDBServer.dll' : 'GDBServer.so' %>",
+        "modelParameters": [
+            "<% if (config['config-file']) { %>",
+            "-f", "<%= config['config-file'] %>\n",
+            "<% } %>",
+            "<% if (Array.isArray(config.args) && config.args.length > 0) { %>",
+            "<%= config.args.join('\\n') %>\n",
+            "<% } %>",
+            "<% else if (typeof config.args === 'string' && config.args.trim().length > 0) { %>",
+            "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
+            "<% } %>",
+            "<% const files = image_files.length ? image_files.map(s => s.file) : [symbol_files[0]?.file ?? ''].filter(Boolean) %>",
+            "<% for (const [idx, file] of files.entries()) { %>",
+            "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
+            "<% } %>"
+        ]
     },
     "launch": {
         "singlecore-launch": {
@@ -30,13 +45,12 @@
             "auxiliaryGdb": false,
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `add-symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
-                "monitor reset halt",
                 "set remote verbose-resume-supported-packet off",
                 "set remote verbose-resume-packet off",
                 "tbreak main"
             ],
             "customResetCommands": [
-                "monitor reset halt",
+                "maintenance packet R00",
                 "maintenance flush register-cache",
                 "maintenance flush dcache",
                 "tbreak main",
@@ -47,20 +61,37 @@
                 "serverParameters": [
                     "-D",
                     "--plugin", "<%= data.gdbServerPlugin %>\n",
-                    "<% if (config['config-file']) { %>",
-                    "-f", "<%= config['config-file'] %>\n",
-                    "<% } %>",
-                    "<% if (Array.isArray(config.args) && config.args.length > 0) { %>",
-                    "<%= config.args.join('\\n') %>\n",
-                    "<% } %>",
-                    "<% else if (typeof config.args === 'string' && config.args.trim().length > 0) { %>",
-                    "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
-                    "<% } %>",
-                    "<% const files = image_files.length ? image_files.map(s => s.file) : [data.program].filter(Boolean) %>",
-                    "<% for (const [idx, file] of files.entries()) { %>",
-                    "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
-                    "<% } %>"
+                    "-C", "GDBServer.port=<%= ports.get(pname) %>\n",
+                    "<%= data.modelParameters.join('\\n') %>"
                 ],
+                "port": "\"<%= ports.get(pname) %>\""
+            },
+            "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
+                "updateConfiguration": "auto"
+            }
+        },
+        "singlecore-attach": {
+            "name": "Arm-FVP@pyOCD (attach)",
+            "type": "gdbtarget",
+            "request": "attach",
+            "cwd": "<%= data.cwd %>",
+            "program": "<%= data.program %>",
+            "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": false,
+            "initCommands": [
+                "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `add-symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
+                "set remote verbose-resume-supported-packet off",
+                "set remote verbose-resume-packet off"
+            ],
+            "customResetCommands": [
+                "maintenance packet R00",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
+                "tbreak main",
+                "continue"
+            ],
+            "target": {
                 "port": "\"<%= ports.get(pname) %>\""
             },
             "cmsis": {
@@ -69,29 +100,30 @@
             }
         }
     },
-    "tasks": [{
-        "label": "CMSIS Load+Run",
-        "type": "shell",
-        "command": "<%= config.model %>",
-        "options": {
-            "cwd": "<%= data.cwd %>",
-            "shell": "<%= data.shell[process.platform] %>"
+    "tasks": [
+        {
+            "label": "CMSIS Run",
+            "type": "shell",
+            "command": "<%= config.model %>",
+            "options": {
+                "cwd": "<%= data.cwd %>",
+                "shell": "<%= data.shell[process.platform] %>"
+            },
+            "args": [
+                "-D",
+                "--plugin", "<%= data.gdbServerPlugin %>\n",
+                "-C", "GDBServer.port=<%= ports.get(start_pname) %>\n",
+                "<%= data.modelParameters.join('\\n') %>"
+            ],
+            "problemMatcher": []
         },
-        "args": [
-            "<% if (config['config-file']) { %>",
-            "-f", "<%= config['config-file'] %>\n",
-            "<% } %>",
-            "<% if (Array.isArray(config.args) && config.args.length > 0) { %>",
-            "<%= config.args.join('\\n') %>\n",
-            "<% } %>",
-            "<% else if (typeof config.args === 'string' && config.args.trim().length > 0) { %>",
-            "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
-            "<% } %>",
-            "<% const files = image_files.map(s => s.file) %>",
-            "<% for (const [idx, file] of files.entries()) { %>",
-            "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
-            "<% } %>"
-        ],
-        "problemMatcher": []
-    }]
+        {
+            "label": "CMSIS Load+Run",
+            "dependsOn": [
+                "CMSIS Run"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": []
+        }
+    ]
 }

--- a/templates/FVP.adapter.json
+++ b/templates/FVP.adapter.json
@@ -31,6 +31,8 @@
             "initCommands": [
                 "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `add-symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
                 "monitor reset halt",
+                "set remote verbose-resume-supported-packet off",
+                "set remote verbose-resume-packet off",
                 "tbreak main"
             ],
             "customResetCommands": [

--- a/templates/FVP.adapter.json
+++ b/templates/FVP.adapter.json
@@ -102,6 +102,16 @@
     },
     "tasks": [
         {
+            "label": "CMSIS Load",
+            "type": "shell",
+            "command": "echo Skipping CMSIS Load: images are loaded by the FVP model when CMSIS Run starts.",
+            "options": {
+                "cwd": "<%= data.cwd %>",
+                "shell": "<%= data.shell[process.platform] %>"
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "CMSIS Run",
             "type": "shell",
             "command": "<%= config.model %>",
@@ -120,6 +130,7 @@
         {
             "label": "CMSIS Load+Run",
             "dependsOn": [
+                "CMSIS Load",
                 "CMSIS Run"
             ],
             "dependsOrder": "sequence",

--- a/templates/FVP.adapter.json
+++ b/templates/FVP.adapter.json
@@ -1,5 +1,6 @@
 {
     "data": {
+        "cwd": "${workspaceFolder}/<%= solution_folder %>",
         "shell": {
             "win32": {
                 "executable": "cmd.exe",
@@ -13,6 +14,57 @@
                 "executable": "/bin/bash",
                 "args": [ "-c" ]
             }
+        },
+        "program": "<%= symbol_files[0]?.file ?? '' %>",
+        "programs": "<%= symbol_files.flatMap(e => (e.pname || !processors?.length) ? e : processors.map(p => ({ ...e, pname: p }))).groupedBy(v => v.pname ?? '') %>",
+        "gdbServerPlugin": "${env:AVH_FVP_PLUGINS}<%= platform === 'win32' ? 'GDBServer.dll' : 'GDBServer.so' %>"
+    },
+    "launch": {
+        "singlecore-launch": {
+            "name": "Arm-FVP@pyOCD (launch)",
+            "type": "gdbtarget",
+            "request": "launch",
+            "cwd": "<%= data.cwd %>",
+            "program": "<%= data.program %>",
+            "gdb": "arm-none-eabi-gdb",
+            "auxiliaryGdb": false,
+            "initCommands": [
+                "<%= data.programs[pname]?.slice(1)?.map(p => p.file ? `add-symbol-file \"${p.file}\"\\n` : '')?.join('') %>",
+                "monitor reset halt",
+                "tbreak main"
+            ],
+            "customResetCommands": [
+                "monitor reset halt",
+                "maintenance flush register-cache",
+                "maintenance flush dcache",
+                "tbreak main",
+                "continue"
+            ],
+            "target": {
+                "server": "<%= config.model %>",
+                "serverParameters": [
+                    "-D",
+                    "--plugin", "<%= data.gdbServerPlugin %>\n",
+                    "<% if (config['config-file']) { %>",
+                    "-f", "<%= config['config-file'] %>\n",
+                    "<% } %>",
+                    "<% if (Array.isArray(config.args) && config.args.length > 0) { %>",
+                    "<%= config.args.join('\\n') %>\n",
+                    "<% } %>",
+                    "<% else if (typeof config.args === 'string' && config.args.trim().length > 0) { %>",
+                    "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
+                    "<% } %>",
+                    "<% const files = image_files.length ? image_files.map(s => s.file) : [data.program].filter(Boolean) %>",
+                    "<% for (const [idx, file] of files.entries()) { %>",
+                    "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
+                    "<% } %>"
+                ],
+                "port": "\"<%= ports.get(pname) %>\""
+            },
+            "cmsis": {
+                "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}",
+                "updateConfiguration": "auto"
+            }
         }
     },
     "tasks": [{
@@ -20,7 +72,7 @@
         "type": "shell",
         "command": "<%= config.model %>",
         "options": {
-            "cwd": "${workspaceFolder}/<%= solution_folder %>",
+            "cwd": "<%= data.cwd %>",
             "shell": "<%= data.shell[process.platform] %>"
         },
         "args": [
@@ -34,8 +86,8 @@
             "<%= config.args.trim().split(/\\s+/).join('\\n') %>\n",
             "<% } %>",
             "<% const files = image_files.map(s => s.file) %>",
-            "<% for (const file of files) { %>",
-            "-a", "<%= file %>\n",
+            "<% for (const [idx, file] of files.entries()) { %>",
+            "-a", "<%= file %><%= idx + 1 < files.length ? '\\n' : '' %>",
             "<% } %>"
         ],
         "problemMatcher": []


### PR DESCRIPTION
> [!NOTE]
> This PR is still under development.
> Please do not merge until this note is removed.

- Add `launch.json` generation support for Arm-FVP.
- Add the FVP GDBServer plugin argument using `${env:AVH_FVP_PLUGINS}`.
- Set the default Arm-FVP GDB server port to `10000`, matching the default port used by the FVP GDBServer plugin.
- Avoid generating a trailing empty `""` argument in FVP `launch.json` and `tasks.json` configuration, because FVP treats it as an empty application path and fails during launch.

Currently, this launch configuration:
- only supports `singlecore-launch`.
- doesn't support `auxiliaryGdb`.